### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/paveg/similarity-go/security/code-scanning/3](https://github.com/paveg/similarity-go/security/code-scanning/3)

To address the issue, an explicit `permissions` block should be added. The least-privilege starting point is `contents: read`, which allows the workflow to clone and access repository code but prevents it from writing to repository contents or performing privileged operations. Since the jobs in the provided workflow only perform checkout, building, testing, running linters, CI steps, and uploading coverage (which uses a secret rather than special permissions), the jobs require at most read access to repository contents.

The recommended fix is to add the following block at the root of the workflow (just after `name` and before `on`):

```yaml
permissions:
  contents: read
```

This will enforce read-only permissions for `GITHUB_TOKEN` for all jobs, adhering to the principle of least privilege, unless individual jobs specify stricter or broader permissions as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
